### PR TITLE
Fix empty MetadataBuilder bug

### DIFF
--- a/src/Metadata/Builder/MetadataBuilder.php
+++ b/src/Metadata/Builder/MetadataBuilder.php
@@ -15,7 +15,7 @@ class MetadataBuilder implements Builder
     private array $columnRequiredProperties;
 
     /** @var TableBuilder[] */
-    private array $tables;
+    private array $tables = [];
 
     public static function create(array $tableRequiredProperties = [], array $columnRequiredProperties = []): self
     {

--- a/tests/phpunit/Metadata/ValueObject/MetadataTest.php
+++ b/tests/phpunit/Metadata/ValueObject/MetadataTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DbExtractor\TableResultFormat\Tests\Metadata\ValueObject;
+
+use Keboola\DbExtractor\TableResultFormat\Metadata\Builder\MetadataBuilder;
+use Keboola\DbExtractor\TableResultFormat\Metadata\ValueObject\Table;
+use PHPStan\Testing\TestCase;
+use PHPUnit\Framework\Assert;
+
+class MetadataTest extends TestCase
+{
+    public function testEmpty(): void
+    {
+        $builder = MetadataBuilder::create();
+        $tableCollection = $builder->build();
+        Assert::assertSame(true, $tableCollection->isEmpty());
+        Assert::assertSame(0, $tableCollection->count());
+        Assert::assertSame([], iterator_to_array($tableCollection->getIterator()));
+    }
+
+    public function testAddTable(): void
+    {
+        $builder = MetadataBuilder::create();
+        $builder
+            ->addTable()
+            ->setName('Table')
+            ->setColumnsNotExpected();
+
+        $tableCollection = $builder->build();
+        Assert::assertSame(false, $tableCollection->isEmpty());
+        Assert::assertSame(1, $tableCollection->count());
+
+        /** @var Table[] $tables */
+        $tables = iterator_to_array($tableCollection->getIterator());
+        Assert::assertCount(1, $tables);
+        Assert::assertSame('Table', $tables[0]->getName());
+    }
+}


### PR DESCRIPTION
Changes:
- Fixed bug, missing default value in `MetadataBuilder::$tables` + tests.
- See: https://github.com/keboola/db-extractor-table-format/pull/11/commits/ab0336a2f241899e9d63c60e85af4240591dcefd