### PR TITLE
Fix DefaultManifestSerializer, nullable can be undefined, eg. in Hive db

### DIFF
--- a/src/Metadata/Manifest/DefaultManifestSerializer.php
+++ b/src/Metadata/Manifest/DefaultManifestSerializer.php
@@ -44,7 +44,7 @@ class DefaultManifestSerializer implements ManifestSerializer
         $options = [
             'type' => $column->getType(),
             'length' => $column->hasLength() ? $column->getLength() : null,
-            'nullable' => $column->isNullable(),
+            'nullable' => $column->hasNullable() ? $column->isNullable() : null,
             'default' => $column->hasDefault() ? (string) $column->getDefault() : null,
         ];
         $options = array_filter($options, fn($value) => $value !== null); // remove null values

--- a/tests/phpunit/Metadata/DefaultGetTablesSerializerTest.php
+++ b/tests/phpunit/Metadata/DefaultGetTablesSerializerTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DbExtractor\TableResultFormat\Tests\Metadata;
+
+use Keboola\DbExtractor\TableResultFormat\Metadata\Builder\MetadataBuilder;
+use Keboola\DbExtractor\TableResultFormat\Metadata\GetTables\DefaultGetTablesSerializer;
+use Keboola\DbExtractor\TableResultFormat\Metadata\GetTables\GetTablesSerializer;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+class DefaultGetTablesSerializerTest extends TestCase
+{
+    private GetTablesSerializer $serializer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->serializer = new DefaultGetTablesSerializer();
+    }
+
+    public function testEmpty(): void
+    {
+        $builder = MetadataBuilder::create();
+        $tables = $builder->build();
+        $serialized = $this->serializer->serialize($tables);
+        Assert::assertSame([], $serialized);
+    }
+
+    public function testMinimal(): void
+    {
+        $builder = MetadataBuilder::create();
+
+        $builder
+            ->addTable()
+            ->setName('table1')
+            ->setSchema('schema1')
+            ->addColumn()
+            ->setName('column1')
+            ->setType('INTEGER');
+
+        $tables = $builder->build();
+
+        $serialized = $this->serializer->serialize($tables);
+        Assert::assertSame([
+            [
+                'name' => 'table1',
+                'schema' => 'schema1',
+                'columns' => [
+                    [
+                        'name' => 'column1',
+                        'type' => 'INTEGER',
+                        'primaryKey' => false,
+                    ],
+                ],
+            ],
+        ], $serialized);
+    }
+
+    public function testComplex(): void
+    {
+        $builder = MetadataBuilder::create();
+
+        $table1 = $builder
+            ->addTable()
+            ->setName('table1')
+            ->setSchema('schema1')
+            ->setCatalog('catalog1')
+            ->setType('TABLE')
+            ->setDescription('table 1 description');
+
+        $table1
+            ->addColumn()
+            ->setOrdinalPosition(0)
+            ->setName('column1')
+            ->setType('INTEGER')
+            ->setPrimaryKey(true)
+            ->setUniqueKey(false)
+            ->setNullable(false)
+            ->setAutoIncrementValue(123);
+
+        $table1
+            ->addColumn()
+            ->setOrdinalPosition(0)
+            ->setName('column2')
+            ->setType('VARCHAR')
+            ->setLength('255')
+            ->setPrimaryKey(false)
+            ->setUniqueKey(true)
+            ->setNullable(true)
+            ->setDefault('text123');
+
+        $builder
+            ->addTable()
+            ->setName('table2')
+            ->setSchema('schema2')
+            ->setCatalog('catalog1')
+            ->setType('VIEW')
+            ->addColumn()
+            ->setName('column3')
+            ->setType('INTEGER');
+
+        $tables = $builder->build();
+
+        $serialized = $this->serializer->serialize($tables);
+        Assert::assertSame([
+            [
+                'name' => 'table1',
+                'schema' => 'schema1',
+                'columns' =>
+                    [
+                        [
+                            'name' => 'column1',
+                            'type' => 'INTEGER',
+                            'primaryKey' => true,
+                        ],
+                        [
+                            'name' => 'column2',
+                            'type' => 'VARCHAR',
+                            'primaryKey' => false,
+                        ],
+                    ],
+            ],
+            [
+                'name' => 'table2',
+                'schema' => 'schema2',
+                'columns' =>
+                    [
+                        [
+                            'name' => 'column3',
+                            'type' => 'INTEGER',
+                            'primaryKey' => false,
+                        ],
+                    ],
+            ],
+        ], $serialized);
+    }
+}

--- a/tests/phpunit/Metadata/DefaultManifestSerializerTest.php
+++ b/tests/phpunit/Metadata/DefaultManifestSerializerTest.php
@@ -21,7 +21,37 @@ class DefaultManifestSerializerTest extends TestCase
         $this->serializer = new DefaultManifestSerializer();
     }
 
-    public function testTableMetadata(): void
+    public function testTableMinimal(): void
+    {
+        $tableBuilder = TableBuilder::create()
+            ->setName('simple')
+            ->setSchema('testdb');
+
+        $tableBuilder
+            ->addColumn()
+            ->setName('Col1')
+            ->setType('INT');
+
+        $table = $tableBuilder->build();
+
+        $expectedOutput = [
+            [
+                'key' => 'KBC.name',
+                'value' => 'simple',
+            ],
+            [
+                'key' => 'KBC.sanitizedName',
+                'value' => 'simple',
+            ],
+            [
+                'key' => 'KBC.schema',
+                'value' => 'testdb',
+            ],
+        ];
+        Assert::assertEquals($expectedOutput, $this->serializer->serializeTable($table));
+    }
+
+    public function testTableComplex(): void
     {
         $tableBuilder = TableBuilder::create()
             ->setName('simple')
@@ -61,7 +91,45 @@ class DefaultManifestSerializerTest extends TestCase
         Assert::assertEquals($expectedOutput, $this->serializer->serializeTable($table));
     }
 
-    public function testColumnMetadata(): void
+    public function testColumnMinimal(): void
+    {
+        $column = ColumnBuilder::create()
+            ->setName('simple')
+            ->setType('varchar')
+            ->build();
+
+        $expectedOutput = [
+            [
+                'key' => 'KBC.datatype.type',
+                'value' => 'varchar',
+            ],
+            // Keboola\Datatype\Definition\Common has default value for "nullable" set to "true"
+            [
+                'key' => 'KBC.datatype.nullable',
+                'value' => true,
+            ],
+            [
+                'key' => 'KBC.datatype.basetype',
+                'value' => 'STRING',
+            ],
+            [
+                'key' => 'KBC.sourceName',
+                'value' => 'simple',
+            ],
+            [
+                'key' => 'KBC.sanitizedName',
+                'value' => 'simple',
+            ],
+            [
+                'key' => 'KBC.primaryKey',
+                'value' => false,
+            ],
+        ];
+
+        Assert::assertEquals($expectedOutput, $this->serializer->serializeColumn($column));
+    }
+
+    public function testColumnComplex(): void
     {
         $column = ColumnBuilder::create()
             ->setName('_weird-I-d')

--- a/tests/phpunit/Metadata/DefaultManifestSerializerTest.php
+++ b/tests/phpunit/Metadata/DefaultManifestSerializerTest.php
@@ -7,12 +7,13 @@ namespace Keboola\DbExtractor\TableResultFormat\Tests\Metadata;
 use Keboola\DbExtractor\TableResultFormat\Metadata\Builder\ColumnBuilder;
 use Keboola\DbExtractor\TableResultFormat\Metadata\Builder\TableBuilder;
 use Keboola\DbExtractor\TableResultFormat\Metadata\Manifest\DefaultManifestSerializer;
+use Keboola\DbExtractor\TableResultFormat\Metadata\Manifest\ManifestSerializer;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 
-class DefaultMetadataSerializerTest extends TestCase
+class DefaultManifestSerializerTest extends TestCase
 {
-    private DefaultManifestSerializer $serializer;
+    private ManifestSerializer $serializer;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
Changes:
- Added more tests.
- Fixed bug in DefaultManifestSerializer, nullable can be undefined, eg. in Hive db.