### PR TITLE
Ignore tables to which we cannot read the list of columns

### DIFF
--- a/src/Exception/NoColumnException.php
+++ b/src/Exception/NoColumnException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DbExtractor\TableResultFormat\Exception;
+
+class NoColumnException extends InvalidArgumentException
+{
+
+}

--- a/src/Metadata/ValueObject/Table.php
+++ b/src/Metadata/ValueObject/Table.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\DbExtractor\TableResultFormat\Metadata\ValueObject;
 
 use Keboola\DbExtractor\TableResultFormat\Exception\InvalidArgumentException;
+use Keboola\DbExtractor\TableResultFormat\Exception\NoColumnException;
 use Keboola\DbExtractor\TableResultFormat\Exception\PropertyNotSetException;
 use Keboola\DbExtractor\TableResultFormat\Metadata\ValueObject;
 
@@ -78,7 +79,7 @@ class Table implements ValueObject
         }
 
         if ($columns && $columns->isEmpty()) {
-            throw new InvalidArgumentException(sprintf('Table "%s" must have at least one column.', $name));
+            throw new NoColumnException(sprintf('Table "%s" must have at least one column.', $name));
         }
 
         $this->name = $name;

--- a/tests/phpunit/Metadata/ValueObject/MetadataTest.php
+++ b/tests/phpunit/Metadata/ValueObject/MetadataTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\DbExtractor\TableResultFormat\Tests\Metadata\ValueObject;
 
+use Keboola\DbExtractor\TableResultFormat\Exception\NoColumnException;
 use Keboola\DbExtractor\TableResultFormat\Metadata\Builder\MetadataBuilder;
 use Keboola\DbExtractor\TableResultFormat\Metadata\ValueObject\Table;
 use PHPStan\Testing\TestCase;
@@ -36,5 +37,43 @@ class MetadataTest extends TestCase
         $tables = iterator_to_array($tableCollection->getIterator());
         Assert::assertCount(1, $tables);
         Assert::assertSame('Table', $tables[0]->getName());
+    }
+
+    public function testTableWithNoColumnsDefault(): void
+    {
+        $builder = MetadataBuilder::create();
+        $builder
+            ->addTable()
+            ->setName('Table');
+        $tableCollection = $builder->build();
+
+        // Table without columns is ignored
+        Assert::assertSame(true, $tableCollection->isEmpty());
+    }
+
+    public function testTableWithNoColumnsAllowed(): void
+    {
+        $builder = MetadataBuilder::create();
+        $builder->setIgnoreTableWithoutColumns(true);
+        $builder
+            ->addTable()
+            ->setName('Table');
+        $tableCollection = $builder->build();
+
+        // Table without columns is ignored
+        Assert::assertSame(true, $tableCollection->isEmpty());
+    }
+
+    public function testTableWithNoColumnsNotAllowed(): void
+    {
+        $builder = MetadataBuilder::create();
+        $builder->setIgnoreTableWithoutColumns(false);
+        $builder
+            ->addTable()
+            ->setName('Table');
+
+        $this->expectException(NoColumnException::class);
+        $this->expectExceptionMessage('Table "Table" must have at least one column.');
+        $tableCollection = $builder->build();
     }
 }


### PR DESCRIPTION
Changes:
- Ignored tables without columns (user cannot read the list of columns, insufficient permissions)
- Solving: https://keboola.atlassian.net/browse/COM-277
- Tested in MySQL: https://github.com/keboola/db-extractor-mysql/pull/126/commits/3c8bfcb271cecbb4ad1f0f922f2512b49aa266ef