### PR TITLE
Add case-insensitive fallback for text search

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     },
     "require": {
         "php": ">=7.4",
+        "ext-mbstring": "*",
         "keboola/common-exceptions": "^1.0",
         "keboola/php-datatypes": "^4.7",
         "keboola/php-utils": "^4.1"

--- a/tests/phpunit/Metadata/ValueObject/ColumnCollectionTest.php
+++ b/tests/phpunit/Metadata/ValueObject/ColumnCollectionTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DbExtractor\TableResultFormat\Tests\Metadata\ValueObject;
+
+use Keboola\DbExtractor\TableResultFormat\Metadata\Builder\MetadataBuilder;
+use Keboola\DbExtractor\TableResultFormat\Metadata\Builder\TableBuilder;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+class ColumnCollectionTest extends TestCase
+{
+    public function testCaseSensitiveSearch(): void
+    {
+        $builder = TableBuilder::create();
+        $builder->setName('testTable');
+        $builder
+            ->addColumn()
+            ->setName('abc')
+            ->setType('integer');
+        $builder
+            ->addColumn()
+            ->setName('aBC')
+            ->setType('integer');
+        $builder
+            ->addColumn()
+            ->setName('AbC')
+            ->setType('integer');
+        $builder
+            ->addColumn()
+            ->setName('aBc')
+            ->setType('integer');
+        $table = $builder->build();
+        $collection = $table->getColumns();
+
+        Assert::assertSame('aBC', $collection->getByName('aBC')->getName());
+        Assert::assertSame('aBC', $collection->getBySanitizedName('aBC')->getName());
+    }
+
+    public function testCaseInsensitiveSearch(): void
+    {
+        $builder = TableBuilder::create();
+        $builder->setName('testTable');
+        $builder
+            ->addColumn()
+            ->setName('aBC')
+            ->setType('integer');
+        $table = $builder->build();
+        $collection = $table->getColumns();
+
+        Assert::assertSame('aBC', $collection->getByName('abc')->getName());
+        Assert::assertSame('aBC', $collection->getBySanitizedName('abc')->getName());
+    }
+}

--- a/tests/phpunit/Metadata/ValueObject/TableCollectionTest.php
+++ b/tests/phpunit/Metadata/ValueObject/TableCollectionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DbExtractor\TableResultFormat\Tests\Metadata\ValueObject;
+
+use Keboola\DbExtractor\TableResultFormat\Metadata\Builder\MetadataBuilder;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+class TableCollectionTest extends TestCase
+{
+    public function testCaseSensitiveSearch(): void
+    {
+        $builder = MetadataBuilder::create();
+        $builder
+            ->addTable()
+            ->setSchema('test')
+            ->setName('abc')
+            ->setColumnsNotExpected();
+        $builder
+            ->addTable()
+            ->setSchema('teST')
+            ->setName('aBC')
+            ->setColumnsNotExpected();
+        $builder
+            ->addTable()
+            ->setSchema('TesT')
+            ->setName('AbC')
+            ->setColumnsNotExpected();
+        $builder
+            ->addTable()
+            ->setSchema('teSt')
+            ->setName('aBc')
+            ->setColumnsNotExpected();
+        $collection = $builder->build();
+
+        $table = $collection->getByNameAndSchema('aBC', 'teST');
+        Assert::assertSame('teST', $table->getSchema());
+        Assert::assertSame('aBC', $table->getName());
+    }
+
+    public function testCaseInsensitiveSearch(): void
+    {
+        $builder = MetadataBuilder::create();
+        $builder
+            ->addTable()
+            ->setSchema('teST')
+            ->setName('aBC')
+            ->setColumnsNotExpected();
+        $collection = $builder->build();
+
+        $table = $collection->getByNameAndSchema('abc', 'test');
+        Assert::assertSame('teST', $table->getSchema());
+        Assert::assertSame('aBC', $table->getName());
+    }
+}


### PR DESCRIPTION
Solving: https://keboola.atlassian.net/browse/COM-292

Changes:
- Some databases can be configured as `case-insensitive` for working with `table` and `column` names (eg. on MySQL, linux platform is case-sensitive and windows is case-insensitive)
- Therefore was added case-insensitive fallback to search methods.