### PR TITLE
Replace empty(), with === ""

### DIFF
--- a/src/Metadata/Builder/ColumnBuilder.php
+++ b/src/Metadata/Builder/ColumnBuilder.php
@@ -97,7 +97,7 @@ class ColumnBuilder implements Builder
         // Trim can be disabled, eg. in MsSQL is one space valid column name
         $name = $trim ? trim($name) : $name;
 
-        if (empty($name)) {
+        if ($name === '') {
             throw new InvalidArgumentException('Column\'s name cannot be empty.');
         }
 
@@ -112,7 +112,7 @@ class ColumnBuilder implements Builder
         $description = $description !== null ? trim($description) : null;
 
         // Normalize, empty string is not allowed
-        $this->description = empty($description) ? null : $description;
+        $this->description = $description === '' ? null : $description;
         return $this;
     }
 
@@ -137,7 +137,7 @@ class ColumnBuilder implements Builder
     public function setLength(?string $length): self
     {
         // Normalize, empty string is not allowed
-        $this->length = empty($length) ? null : $length;
+        $this->length = $length === '' ? null : $length;
         return $this;
     }
 
@@ -192,7 +192,7 @@ class ColumnBuilder implements Builder
     private static function sanitizeName(string $name): string
     {
         // In some databases, eg. MsSQL is one space valid column name, so we must it sanitize to non-empty string
-        if (empty(trim($name))) {
+        if (trim($name) === '') {
             // Name cannot start/end with special char, it is trim in ColumnNameSanitizer
             $name = 'empty' . preg_replace('~\s~', '_', $name) . 'name';
         }

--- a/src/Metadata/Builder/ForeignKeyBuilder.php
+++ b/src/Metadata/Builder/ForeignKeyBuilder.php
@@ -58,7 +58,7 @@ class ForeignKeyBuilder implements Builder
     {
         $name = trim($name);
 
-        if (empty($name)) {
+        if ($name === '') {
             throw new InvalidArgumentException('ForeignKey\'s name cannot be empty string.');
         }
 
@@ -70,7 +70,7 @@ class ForeignKeyBuilder implements Builder
     {
         $refSchema = trim($refSchema);
 
-        if (empty($refSchema)) {
+        if ($refSchema === '') {
             throw new InvalidArgumentException('ForeignKey\'s refSchema cannot be empty string.');
         }
 
@@ -82,7 +82,7 @@ class ForeignKeyBuilder implements Builder
     {
         $refTable = trim($refTable);
 
-        if (empty($refTable)) {
+        if ($refTable === '') {
             throw new InvalidArgumentException('ForeignKey\'s refTable cannot be empty string.');
         }
 
@@ -94,7 +94,7 @@ class ForeignKeyBuilder implements Builder
     {
         $refColumn = trim($refColumn);
 
-        if (empty($refColumn)) {
+        if ($refColumn === '') {
             throw new InvalidArgumentException('ForeignKey\'s refColumn cannot be empty string.');
         }
 

--- a/src/Metadata/Builder/TableBuilder.php
+++ b/src/Metadata/Builder/TableBuilder.php
@@ -114,7 +114,7 @@ class TableBuilder implements Builder
         // Trim
         $name = trim($name);
 
-        if (empty($name)) {
+        if ($name === '') {
             throw new InvalidArgumentException('Table\'s name cannot be empty.');
         }
 
@@ -129,7 +129,7 @@ class TableBuilder implements Builder
         $description = $description !== null ? trim($description) : null;
 
         // Normalize, empty string is not allowed
-        $this->description = empty($description) ? null : $description;
+        $this->description = $description === '' ? null : $description;
         return $this;
     }
 
@@ -139,7 +139,7 @@ class TableBuilder implements Builder
         $schema = $schema !== null ? trim($schema) : null;
 
         // Normalize, empty string is not allowed
-        $this->schema = empty($schema) ? null : $schema;
+        $this->schema = $schema === '' ? null : $schema;
         return $this;
     }
 
@@ -149,7 +149,7 @@ class TableBuilder implements Builder
         $catalog = $catalog !== null ? trim($catalog) : null;
 
         // Normalize, empty string is not allowed
-        $this->catalog = empty($catalog) ? null : $catalog;
+        $this->catalog = $catalog === '' ? null : $catalog;
         return $this;
     }
 
@@ -159,7 +159,7 @@ class TableBuilder implements Builder
         $tablespaceName = $tablespaceName !== null ? trim($tablespaceName) : null;
 
         // Normalize, empty string is not allowed
-        $this->tablespaceName = empty($tablespaceName) ? null : $tablespaceName;
+        $this->tablespaceName = $tablespaceName === '' ? null : $tablespaceName;
         return $this;
     }
 
@@ -169,13 +169,13 @@ class TableBuilder implements Builder
         $owner = $owner !== null ? trim($owner) : null;
 
         // Normalize, empty string is not allowed
-        $this->owner = empty($owner) ? null : $owner;
+        $this->owner = $owner === '' ? null : $owner;
         return $this;
     }
 
     public function setType(string $type): self
     {
-        if (empty($type)) {
+        if ($type === '') {
             throw new InvalidArgumentException('Table\'s type cannot be empty string.');
         }
 

--- a/src/Metadata/ValueObject/Column.php
+++ b/src/Metadata/ValueObject/Column.php
@@ -63,23 +63,23 @@ class Column implements ValueObject
         ?ForeignKey $foreignKey,
         array $constraints
     ) {
-        if (empty($name)) {
+        if ($name === '') {
             throw new InvalidArgumentException('Column\'s name cannot be empty.');
         }
 
-        if (empty($sanitizedName)) {
+        if ($sanitizedName === '') {
             throw new InvalidArgumentException('Column\'s sanitized name cannot be empty.');
         }
 
-        if ($description !== null && empty($description)) {
+        if ($description !== null && $description === '') {
             throw new InvalidArgumentException('Column\'s description cannot be empty string, use null.');
         }
 
-        if (empty($type)) {
+        if ($type === '') {
             throw new InvalidArgumentException('Column\'s type cannot be empty.');
         }
 
-        if ($length !== null && empty($length)) {
+        if ($length !== null && $length === '') {
             throw new InvalidArgumentException('Column\'s length cannot be empty string, use null.');
         }
 

--- a/src/Metadata/ValueObject/Column.php
+++ b/src/Metadata/ValueObject/Column.php
@@ -71,7 +71,7 @@ class Column implements ValueObject
             throw new InvalidArgumentException('Column\'s sanitized name cannot be empty.');
         }
 
-        if ($description !== null && $description === '') {
+        if ($description === '') {
             throw new InvalidArgumentException('Column\'s description cannot be empty string, use null.');
         }
 
@@ -79,7 +79,7 @@ class Column implements ValueObject
             throw new InvalidArgumentException('Column\'s type cannot be empty.');
         }
 
-        if ($length !== null && $length === '') {
+        if ($length === '') {
             throw new InvalidArgumentException('Column\'s length cannot be empty string, use null.');
         }
 

--- a/src/Metadata/ValueObject/ForeignKey.php
+++ b/src/Metadata/ValueObject/ForeignKey.php
@@ -23,11 +23,11 @@ class ForeignKey implements ValueObject
      */
     public function __construct(?string $name, ?string $refSchema, string $refTable, string $refColumn)
     {
-        if ($name !== null && $name === '') {
+        if ($name === '') {
             throw new InvalidArgumentException('Name of foreign key cannot be empty string.');
         }
 
-        if ($refSchema !== null && $refSchema === '') {
+        if ($refSchema === '') {
             throw new InvalidArgumentException('Ref schema of foreign key cannot be empty string.');
         }
 

--- a/src/Metadata/ValueObject/ForeignKey.php
+++ b/src/Metadata/ValueObject/ForeignKey.php
@@ -23,19 +23,19 @@ class ForeignKey implements ValueObject
      */
     public function __construct(?string $name, ?string $refSchema, string $refTable, string $refColumn)
     {
-        if ($name !== null && empty($name)) {
+        if ($name !== null && $name === '') {
             throw new InvalidArgumentException('Name of foreign key cannot be empty string.');
         }
 
-        if ($refSchema !== null && empty($refSchema)) {
+        if ($refSchema !== null && $refSchema === '') {
             throw new InvalidArgumentException('Ref schema of foreign key cannot be empty string.');
         }
 
-        if (empty($refTable)) {
+        if ($refTable === '') {
             throw new InvalidArgumentException('Ref table cannot be empty.');
         }
 
-        if (empty($refColumn)) {
+        if ($refColumn === '') {
             throw new InvalidArgumentException('Ref column cannot be empty.');
         }
 

--- a/src/Metadata/ValueObject/Table.php
+++ b/src/Metadata/ValueObject/Table.php
@@ -54,27 +54,27 @@ class Table implements ValueObject
             throw new InvalidArgumentException('Table\'s sanitized name cannot be empty.');
         }
 
-        if ($description !== null && $description === '') {
+        if ($description === '') {
             throw new InvalidArgumentException('Table\'s description cannot be empty string, use null.');
         }
 
-        if ($schema !== null && $schema === '') {
+        if ($schema === '') {
             throw new InvalidArgumentException('Table\'s schema cannot be empty string, use null.');
         }
 
-        if ($catalog !== null && $catalog === '') {
+        if ($catalog === '') {
             throw new InvalidArgumentException('Table\'s catalog cannot be empty string, use null.');
         }
 
-        if ($tablespaceName !== null && $tablespaceName === '') {
+        if ($tablespaceName === '') {
             throw new InvalidArgumentException('Table\'s tablespaceName cannot be empty string, use null.');
         }
 
-        if ($owner !== null && $owner === '') {
+        if ($owner === '') {
             throw new InvalidArgumentException('Table\'s owner cannot be empty string, use null.');
         }
 
-        if ($type !== null && $type === '') {
+        if ($type === '') {
             throw new InvalidArgumentException('Table\'s type cannot be empty string, use null.');
         }
 

--- a/src/Metadata/ValueObject/Table.php
+++ b/src/Metadata/ValueObject/Table.php
@@ -46,35 +46,35 @@ class Table implements ValueObject
         ?int $rowCount,
         ?ColumnCollection $columns
     ) {
-        if (empty($name)) {
+        if ($name === '') {
             throw new InvalidArgumentException('Table\'s name cannot be empty.');
         }
 
-        if (empty($sanitizedName)) {
+        if ($sanitizedName === '') {
             throw new InvalidArgumentException('Table\'s sanitized name cannot be empty.');
         }
 
-        if ($description !== null && empty($description)) {
+        if ($description !== null && $description === '') {
             throw new InvalidArgumentException('Table\'s description cannot be empty string, use null.');
         }
 
-        if ($schema !== null && empty($schema)) {
+        if ($schema !== null && $schema === '') {
             throw new InvalidArgumentException('Table\'s schema cannot be empty string, use null.');
         }
 
-        if ($catalog !== null && empty($catalog)) {
+        if ($catalog !== null && $catalog === '') {
             throw new InvalidArgumentException('Table\'s catalog cannot be empty string, use null.');
         }
 
-        if ($tablespaceName !== null && empty($tablespaceName)) {
+        if ($tablespaceName !== null && $tablespaceName === '') {
             throw new InvalidArgumentException('Table\'s tablespaceName cannot be empty string, use null.');
         }
 
-        if ($owner !== null && empty($owner)) {
+        if ($owner !== null && $owner === '') {
             throw new InvalidArgumentException('Table\'s owner cannot be empty string, use null.');
         }
 
-        if ($type !== null && empty($type)) {
+        if ($type !== null && $type === '') {
             throw new InvalidArgumentException('Table\'s type cannot be empty string, use null.');
         }
 

--- a/tests/phpunit/Metadata/Builder/ColumnBuilderTest.php
+++ b/tests/phpunit/Metadata/Builder/ColumnBuilderTest.php
@@ -254,4 +254,19 @@ class ColumnBuilderTest extends BaseBuilderTest
         Assert::assertSame(' ', $valueObject->getName());
         Assert::assertSame('empty_name', $valueObject->getSanitizedName());
     }
+
+    public function testNotEmptyName(): void
+    {
+        // empty("0") = true,
+        // but "0" is valid column name in MsSQL, so empty method cannot be used in code
+        $name = '0';
+
+        $builder = $this->createBuilder();
+        $builder->setName($name, false);
+        $builder->setType('INT');
+
+        $valueObject = $builder->build();
+        Assert::assertSame('0', $valueObject->getName());
+        Assert::assertSame('0', $valueObject->getSanitizedName());
+    }
 }


### PR DESCRIPTION
Changes:
- `empty` function in code was replaced by `=== ""` to check empty string, because `empty("0") = true` and `"0"` is valid column name in MsSQL.