### PR TITLE
Add better sanitization of whitespace column name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require": {
         "php": ">=7.4",
         "ext-mbstring": "*",
+        "ext-json": "*",
         "keboola/common-exceptions": "^1.0",
         "keboola/php-datatypes": "^4.7",
         "keboola/php-utils": "^4.1"
@@ -29,8 +30,7 @@
     "require-dev": {
         "keboola/coding-standard": ">=9.0",
         "phpstan/phpstan": "^0.12.2",
-        "phpunit/phpunit": "^9.1",
-        "ext-json": "*"
+        "phpunit/phpunit": "^9.1"
     },
     "scripts": {
         "tests": "./vendor/bin/phpunit",

--- a/src/Metadata/Builder/ColumnBuilder.php
+++ b/src/Metadata/Builder/ColumnBuilder.php
@@ -191,12 +191,16 @@ class ColumnBuilder implements Builder
 
     private static function sanitizeName(string $name): string
     {
+        $sanitized = ColumnNameSanitizer::sanitize($name);
+
         // In some databases, eg. MsSQL is one space valid column name, so we must it sanitize to non-empty string
-        if (trim($name) === '') {
+        if ($sanitized === '') {
             // Name cannot start/end with special char, it is trim in ColumnNameSanitizer
-            $name = 'empty' . preg_replace('~\s~', '_', $name) . 'name';
+            $sanitized = ColumnNameSanitizer::sanitize(
+                'empty' . preg_replace('~\s~', '_', $name) . 'name'
+            );
         }
 
-        return ColumnNameSanitizer::sanitize($name);
+        return $sanitized;
     }
 }

--- a/src/Metadata/ValueObject/Column.php
+++ b/src/Metadata/ValueObject/Column.php
@@ -68,19 +68,31 @@ class Column implements ValueObject
         }
 
         if ($sanitizedName === '') {
-            throw new InvalidArgumentException('Column\'s sanitized name cannot be empty.');
+            throw new InvalidArgumentException(sprintf(
+                'Column\'s %s sanitized name cannot be empty.',
+                json_encode($name)
+            ));
         }
 
         if ($description === '') {
-            throw new InvalidArgumentException('Column\'s description cannot be empty string, use null.');
+            throw new InvalidArgumentException(sprintf(
+                'Column\'s %s description cannot be empty string, use null.',
+                json_encode($name)
+            ));
         }
 
         if ($type === '') {
-            throw new InvalidArgumentException('Column\'s type cannot be empty.');
+            throw new InvalidArgumentException(sprintf(
+                'Column\'s %s type cannot be empty.',
+                json_encode($name)
+            ));
         }
 
         if ($length === '') {
-            throw new InvalidArgumentException('Column\'s length cannot be empty string, use null.');
+            throw new InvalidArgumentException(sprintf(
+                'Column\'s %s length cannot be empty string, use null.',
+                json_encode($name)
+            ));
         }
 
         if (!$autoIncrement && $autoIncrementValue !== null) {

--- a/tests/phpunit/Metadata/Builder/ColumnBuilderTest.php
+++ b/tests/phpunit/Metadata/Builder/ColumnBuilderTest.php
@@ -255,6 +255,19 @@ class ColumnBuilderTest extends BaseBuilderTest
         Assert::assertSame('empty_name', $valueObject->getSanitizedName());
     }
 
+    public function testWhitespaceSanitizedName(): void
+    {
+        $name = "\u{2001}"; // white space - EM quad - not removed by trim
+
+        $builder = $this->createBuilder();
+        $builder->setName($name);
+        $builder->setType('INT');
+
+        $valueObject = $builder->build();
+        Assert::assertSame($name, $valueObject->getName());
+        Assert::assertSame('empty_name', $valueObject->getSanitizedName());
+    }
+
     public function testNotEmptyName(): void
     {
         // empty("0") = true,


### PR DESCRIPTION
Solving: https://keboola.atlassian.net/browse/COM-360

Changes:
- Column name that contains whitespace that is not handled by `trim` is correctly sanitized.