### PR TITLE
Fix columns order mismatch

### DIFF
--- a/tests/phpunit/Metadata/ValueObject/ColumnCollectionTest.php
+++ b/tests/phpunit/Metadata/ValueObject/ColumnCollectionTest.php
@@ -52,4 +52,88 @@ class ColumnCollectionTest extends TestCase
         Assert::assertSame('aBC', $collection->getByName('abc')->getName());
         Assert::assertSame('aBC', $collection->getBySanitizedName('abc')->getName());
     }
+
+    public function testSortByOrdinalPosition(): void
+    {
+        $builder = TableBuilder::create();
+        $builder->setName('testTable');
+
+        $builder
+            ->addColumn()
+            ->setName('D')
+            ->setType('integer')
+            ->setOrdinalPosition(4);
+
+        $builder
+            ->addColumn()
+            ->setName('B')
+            ->setType('integer')
+            ->setOrdinalPosition(2);
+
+        $builder
+            ->addColumn()
+            ->setName('A')
+            ->setType('integer')
+            ->setOrdinalPosition(1);
+
+        $builder
+            ->addColumn()
+            ->setName('C')
+            ->setType('integer')
+            ->setOrdinalPosition(3);
+
+        $table = $builder->build();
+        $collection = $table->getColumns();
+        Assert::assertSame(['A', 'B', 'C', 'D'], $collection->getNames());
+    }
+
+    public function testSortOrdinalPositionNull(): void
+    {
+        $builder = TableBuilder::create();
+        $builder->setName('testTable');
+
+        $builder
+            ->addColumn()
+            ->setName('A')
+            ->setType('integer');
+
+        $builder
+            ->addColumn()
+            ->setName('B')
+            ->setType('integer');
+
+        $builder
+            ->addColumn()
+            ->setName('C')
+            ->setType('integer');
+
+        $builder
+            ->addColumn()
+            ->setName('D')
+            ->setType('integer');
+
+        $table = $builder->build();
+        $collection = $table->getColumns();
+        Assert::assertSame(['A', 'B', 'C', 'D'], $collection->getNames());
+    }
+
+    public function testSortOrdinalPositionNullMultiple(): void
+    {
+        $builder = TableBuilder::create();
+        $builder->setName('testTable');
+
+        $expectedOrder = [];
+        for ($i=0; $i<100; $i++) {
+            $name = 'COL' . $i;
+            $expectedOrder[] = $name;
+            $builder
+                ->addColumn()
+                ->setName($name)
+                ->setType('integer');
+        }
+
+        $table = $builder->build();
+        $collection = $table->getColumns();
+        Assert::assertSame($expectedOrder, $collection->getNames());
+    }
 }

--- a/tests/phpunit/Metadata/ValueObject/ColumnCollectionTest.php
+++ b/tests/phpunit/Metadata/ValueObject/ColumnCollectionTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\DbExtractor\TableResultFormat\Tests\Metadata\ValueObject;
 
-use Keboola\DbExtractor\TableResultFormat\Metadata\Builder\MetadataBuilder;
+use Keboola\DbExtractor\TableResultFormat\Exception\InvalidArgumentException;
 use Keboola\DbExtractor\TableResultFormat\Metadata\Builder\TableBuilder;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
@@ -135,5 +135,64 @@ class ColumnCollectionTest extends TestCase
         $table = $builder->build();
         $collection = $table->getColumns();
         Assert::assertSame($expectedOrder, $collection->getNames());
+    }
+
+    public function testOrdinalPositionMustBeSetToAllOrNone(): void
+    {
+        $builder = TableBuilder::create();
+        $builder->setName('testTable');
+
+        $builder
+            ->addColumn()
+            ->setName('A')
+            ->setType('integer');
+
+        $builder
+            ->addColumn()
+            ->setName('B')
+            ->setType('integer');
+
+        $builder
+            ->addColumn()
+            ->setName('C')
+            ->setOrdinalPosition(2)
+            ->setType('integer');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Set "ordinalPosition" to all columns, or none. ' .
+            'Column "C" has hasOrdinalPosition = "true", but the previous value is "false".'
+        );
+        $builder->build();
+    }
+
+    public function testOrdinalPositionMustBeSetToAllOrNone2(): void
+    {
+        $builder = TableBuilder::create();
+        $builder->setName('testTable');
+
+        $builder
+            ->addColumn()
+            ->setName('A')
+            ->setOrdinalPosition(1)
+            ->setType('integer');
+
+        $builder
+            ->addColumn()
+            ->setName('B')
+            ->setOrdinalPosition(2)
+            ->setType('integer');
+
+        $builder
+            ->addColumn()
+            ->setName('B')
+            ->setType('integer');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Set "ordinalPosition" to all columns, or none. ' .
+            'Column "B" has hasOrdinalPosition = "false", but the previous value is "true".'
+        );
+        $builder->build();
     }
 }


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/COM-786

Problem je v tomto kode:
https://github.com/keboola/db-extractor-table-format/blob/9cb21260819bd0c6facffb9a1eb1f6f68d2eb63c/src/Metadata/ValueObject/ColumnCollection.php#L39-L44

- Je tam ValueObject `column`, ktora ma volitelnu property `ordinalPosition`.
- Ordinal position sme doteraz vzdy nastavovali, takze chyba sa neprejavila.
- V tomto pripade sme ju ale pri metadatach custom query nevyplnili (ex-mssql, ex-snfk).
- Ak je slpcov `<=16` tak `usort` neprehadze poradie.
- Ak je ich viac, tak sort algoritmus (quic sort?) si ich rozdeli a prehadze, kedze vsetky polozky maju `ordinalPosition = null`, tj. su si rovne.
- Vid prvy commit -> padajuci test, ... pri malom pocte stlpcov sa chyba neprejavi.